### PR TITLE
[BackEnd] Added API calls to create game, add user and start game

### DIFF
--- a/BackEnd/models/game.js
+++ b/BackEnd/models/game.js
@@ -5,6 +5,7 @@ var gameSchema = new Schema({
 	type: String,
 	unique: true,
     },
+    started: Boolean,
     organizerName: String,
     centralSafeZone: { type: Schema.Types.ObjectId, ref: 'safezone' },
     alivePlayers: [{ type: Schema.Types.ObjectId, ref: 'player' }],

--- a/BackEnd/routes.js
+++ b/BackEnd/routes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import config from './config';
 import mongoose from 'mongoose';
 import Player from './models/player';
+import Game from './models/game';
 
 const router = express.Router();
 
@@ -26,7 +27,125 @@ router.get('/config', (req, res, next) => {
     res.json(config.client);
 });
 
+router.post('/createGame', (req, res) => {
+    if (req.body.loginCode == null || req.body.orgName == null) {
+	res.sendStatus(400);
+	return;
+    }
+    Game.findOne({ gameCode: req.body.loginCode }, (err, game) => {
+	if (game)
+	    res.sendStatus(400);
+	else {
+	    var newGame = new Game({ gameCode: req.body.loginCode,
+				     started: false,
+				     organizerName: req.body.orgName});
+	    newGame.save((err) => {
+		if (err)
+		    res.sendStatus(500);
+		else
+		    res.sendStatus(200);
+	    });
+	}
+    });
+});
+
+router.post('/addUser', (req, res) => {
+    if(req.body.username == null || req.body.loginCode == null || req.body.mac == null
+       || req.body.x == null || req.body.y == null) {
+	res.sendStatus(400);
+	return;
+    }
+    Player.findOne({ username: req.body.username }, (err, obj) => {
+	if (obj)
+	    res.sendStatus(400);
+	else {
+	    Game.findOne({ gameCode: req.body.loginCode, started: false }, (err, game) => {
+		if(!game)
+		    res.sendStatus(400);
+		else {
+		    var newPlayer = new Player({ username: req.body.username,
+						 alive: true,
+						 macAddress: req.body.mac,
+						 game: game._id,
+						 location: [req.body.x, req.body.y] });
+		    newPlayer.save((err, player) => {
+			if (err)
+			    res.sendStatus(500);
+			else {
+			    game.alivePlayers.push(player._id);
+			    game.save((err) => {
+				if (err)
+				    res.sendStatus(500);
+				else
+				    res.status(200).send(player._id);
+			    });
+			}
+		    });
+		}
+	    });
+	}
+    });
+});
+
+// Fisher-Yates Shuffle algorithm thanks to StackOverflow
+// https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+function shuffle(array) {
+    var currentIndex = array.length, temporaryValue, randomIndex;
+
+    // While there remain elements to shuffle...
+    while (0 !== currentIndex) {
+
+	// Pick a remaining element...
+	randomIndex = Math.floor(Math.random() * currentIndex);
+	currentIndex -= 1;
+
+	// And swap it with the current element.
+	temporaryValue = array[currentIndex];
+	array[currentIndex] = array[randomIndex];
+	array[randomIndex] = temporaryValue;
+    }
+
+    return array;
+}
+
+router.post('/startGame', (req, res) => {
+    if(req.body.loginCode == null) {
+	res.sendStatus(400);
+	return;
+    }
+    Game.findOne({ gameCode: req.body.loginCode, started: false }, (err, game) => {
+	shuffle(game.alivePlayers);
+	for(var i = 0, len = game.alivePlayers.length; i < len - 1; i++) {
+	    Player.findOneAndUpdate({ _id: game.alivePlayers[i] },
+				    { $set: { target: game.alivePlayers[i + 1] } },
+				    (err, doc) => {
+					if (err) {
+					    console.log("Failed to add target to player");
+					}
+				    });
+	}
+	Player.findOneAndUpdate({ _id: game.alivePlayers[game.alivePlayers.length - 1]},
+				{ $set: { target: game.alivePlayers[0] } },
+				(err, doc) => {
+				    if (err) {
+					console.log("Failed to add target to player");
+				    }
+				});
+	game.started = true;
+	game.save((err) => {
+	    if (err)
+		res.sendStatus(500);
+	    else
+		res.sendStatus(200);
+	});
+    });
+});
+
 router.post('/updateLocation', (req, res) => {
+    if(req.body.username == null || req.body.x == null || req.body.y == null) {
+	res.sendStatus(400);
+	return;
+    }
     Player.findOneAndUpdate({ username: req.body.username },
 			    { $set: { location: [req.body.x, req.body.y] } },
 			    (err, doc) => {


### PR DESCRIPTION
createGame adds a new game to the games collection and sets up its
initial state as long as the inputted loginCode does not already exist.

addUser adds a player to a pre-existing but not started game as long
as the username is not taken already.

startGame sets the game state to started and calculates the targets
of all the players by shuffling the list of players and generating a
circular linked list.